### PR TITLE
Improve CLI output with rich

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -1,6 +1,10 @@
 from task import Task
 from storage import load_tasks, save_tasks
 from datetime import datetime
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
 
 
 def add_task(description):
@@ -15,7 +19,7 @@ def add_task(description):
     tasks.append(new_task)
     save_tasks(tasks)
 
-    print(f"Task added successfully (ID: {id})")
+    console.print(f"Task added successfully (ID: {id})", style="bold bright_cyan")
 
 def delete_task(id: int):
     tasks = load_tasks()
@@ -28,9 +32,9 @@ def delete_task(id: int):
     if task_to_rid:
         tasks.remove(task_to_rid)
         save_tasks(tasks)
-        print(f"Task with ID: {id} deleted successfully")
+        console.print(f"Task with ID: {id} deleted successfully", style="bold bright_cyan")
     else:
-        print(f"Task with ID: {id} not found")
+        console.print(f"Task with ID: {id} not found", style="bold bright_red")
 
 def update_task(id: int, description: str):
     tasks = load_tasks()
@@ -44,9 +48,9 @@ def update_task(id: int, description: str):
         task_to_update.description = description
         task_to_update.updated_at = datetime.now().isoformat()
         save_tasks(tasks)
-        print(f"Task with ID: {id} updated successfully")
+        console.print(f"Task with ID: {id} updated successfully", style="bold bright_cyan")
     else:
-        print(f"Task with ID: {id} not found")
+        console.print(f"Task with ID: {id} not found", style="bold bright_red")
 
 def change_status(id: int, status: str):
     if status in [Task.STATUS_TODO, Task.STATUS_IN_PROGRESS, Task.STATUS_DONE]:
@@ -62,29 +66,59 @@ def change_status(id: int, status: str):
             task_to_update.status = status
             task_to_update.updated_at = datetime.now().isoformat()
             save_tasks(tasks)
-            print(f"Task with ID: {id} marked as {status} successfully")
+            console.print(
+                f"Task with ID: {id} marked as {status} successfully",
+                style="bold bright_cyan",
+            )
         else:
-            print(f"Task with ID: {id} not found")
+            console.print(f"Task with ID: {id} not found", style="bold bright_red")
 
     else:
-        print(f"Invalid status: {status}. Valid statuses are: To Do, In Progress, Done")
+        console.print(
+            f"Invalid status: {status}. Valid statuses are: To Do, In Progress, Done",
+            style="bold bright_red",
+        )
 
-def list_tasks(status:str = None):
+def list_tasks(status: str | None = None):
     tasks = load_tasks()
 
     if status and status not in [Task.STATUS_TODO, Task.STATUS_IN_PROGRESS, Task.STATUS_DONE]:
-        print(f"Invalid status: {status}. Valid statuses are: To Do, In Progress, Done")
+        console.print(
+            f"Invalid status: {status}. Valid statuses are: To Do, In Progress, Done",
+            style="bold bright_red",
+        )
         return
 
     if status:
         tasks = [t for t in tasks if t.status == status]
-        print(f"Tasks with status '{status}':")
+        console.print(f"Tasks with status '{status}':", style="bold bright_magenta")
     else:
-        print("All tasks:")
+        console.print("All tasks:", style="bold bright_magenta")
 
     if not tasks:
-        print("No tasks found.")
+        console.print("No tasks found.", style="bright_yellow")
         return
 
+    table = Table(show_header=True, header_style="bold bright_blue")
+    table.add_column("ID", style="bright_white")
+    table.add_column("Description", style="bright_white")
+    table.add_column("Status", style="bright_white")
+    table.add_column("Created", style="bright_white")
+    table.add_column("Updated", style="bright_white")
+
+    status_colors = {
+        Task.STATUS_TODO: "bright_magenta",
+        Task.STATUS_IN_PROGRESS: "bright_yellow",
+        Task.STATUS_DONE: "bright_green",
+    }
+
     for t in tasks:
-        print(f"[{t.id}] {t.description} — {t.status}")
+        table.add_row(
+            str(t.id),
+            t.description,
+            f"[{status_colors.get(t.status, 'white')}]" + t.status + "[/]",
+            t.created_at.split("T")[0],
+            t.updated_at.split("T")[0],
+        )
+
+    console.print(table)

--- a/main.py
+++ b/main.py
@@ -5,37 +5,44 @@ from commands import (
     update_task,
     change_status,
     list_tasks,
+    console,
 )
 
 def main():
     if len(sys.argv) < 2:
-        print("Please provide a command: add, delete, update, change_status, list")
+        console.print(
+            "Please provide a command: add, delete, update, change_status, list",
+            style="bright_yellow",
+        )
         return
     
     command = sys.argv[1]
 
     if command == "add":
         if len(sys.argv) < 3:
-            print("Usage: add \"description\"")
+            console.print("Usage: add \"description\"", style="bright_yellow")
             return
         description = sys.argv[2]
         add_task(description)
 
     elif command == "delete":
         if len(sys.argv) < 3:
-            print("Usage: delete <id>")
+            console.print("Usage: delete <id>", style="bright_yellow")
             return
         delete_task(int(sys.argv[2]))
 
     elif command == "update":
         if len(sys.argv) < 4:
-            print("Usage: update <id> \"new description\"")
+            console.print(
+                "Usage: update <id> \"new description\"",
+                style="bright_yellow",
+            )
             return
         update_task(int(sys.argv[2]), sys.argv[3])
 
     elif command == "status":
         if len(sys.argv) < 4:
-            print("Usage: status <id> <status>")
+            console.print("Usage: status <id> <status>", style="bright_yellow")
             return
         change_status(int(sys.argv[2]), sys.argv[3])
 
@@ -44,7 +51,7 @@ def main():
         list_tasks(status)
 
     else:
-        print(f"Unknown command: {command}")
+        console.print(f"Unknown command: {command}", style="bold bright_red")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add `rich` console and table support in the command helpers
- colorize command line helper messages
- display task lists using rich tables
- propagate console to main entry for uniform styling

## Testing
- `python -m unittest test.py -v`

------
https://chatgpt.com/codex/tasks/task_e_6849cc8b11b4832dacf9b8375863a4b3