### PR TITLE
Improve command case handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Taskitor is a command-line application written in Python that allows users to manage their tasks through simple CLI commands. Tasks are stored in a local JSON file and can have three possible statuses: "To Do", "In Progress", and "Done".
+Taskitor is a command-line application written in Python that allows users to manage their tasks through simple CLI commands. Tasks are stored in a local JSON file and can have three possible statuses: "to-do", "in-progress", and "done".
 
 The goal is to enhance the visual appearance of the CLI output using the `rich` library, making the interface more readable and user-friendly.
 

--- a/taskitor/main.py
+++ b/taskitor/main.py
@@ -16,7 +16,7 @@ def main():
         )
         return
     
-    command = sys.argv[1]
+    command = sys.argv[1].lower()
 
     if command == "add":
         if len(sys.argv) < 3:

--- a/taskitor/task.py
+++ b/taskitor/task.py
@@ -3,16 +3,16 @@ from datetime import datetime
 
 
 class Task:
-    def __init__(self, id, description, status="To Do", created_at=None, updated_at=None):
+    def __init__(self, id, description, status="to-do", created_at=None, updated_at=None):
         self.id = id
         self.description = description
         self.status = status
         self.created_at = created_at or datetime.now().isoformat()
         self.updated_at = updated_at or self.created_at
 
-    STATUS_TODO = "To Do"
-    STATUS_IN_PROGRESS = "In Progress"
-    STATUS_DONE = "Done"
+    STATUS_TODO = "to-do"
+    STATUS_IN_PROGRESS = "in-progress"
+    STATUS_DONE = "done"
 
     def to_dict(self):
         return {

--- a/test.py
+++ b/test.py
@@ -1,7 +1,11 @@
 import unittest
 from io import StringIO
 from contextlib import redirect_stdout
-from taskitor.commands import add_task, delete_task, update_task, change_status, list_tasks
+from unittest.mock import patch
+import sys
+import os
+from taskitor.commands import add_task, delete_task, update_task, change_status, list_tasks, normalize_status
+from taskitor.main import main
 import taskitor.storage as storage
 from taskitor.storage import load_tasks, save_tasks
 from taskitor.task import Task
@@ -10,6 +14,10 @@ class TestTaskCommands(unittest.TestCase):
     def setUp(self):
         storage.FILE_PATH = "test_tasks.json"
         save_tasks([])
+
+    def tearDown(self):
+        if os.path.exists(storage.FILE_PATH):
+            os.remove(storage.FILE_PATH)
     
     def test_add_task(self):
         add_task("Test task")
@@ -77,7 +85,6 @@ class TestListTasks(unittest.TestCase):
 
     def test_list_tasks_by_status(self):
         add_task("Tarea A")
-        tasks = save_tasks  # reload to get real ID
         tasks = load_tasks()
         change_status(tasks[0].id, Task.STATUS_DONE)
 
@@ -86,7 +93,7 @@ class TestListTasks(unittest.TestCase):
             list_tasks(Task.STATUS_DONE)
         output = f.getvalue()
 
-        self.assertIn("Tasks with status 'Done'", output)
+        self.assertIn("Tasks with status 'done'", output)
         self.assertIn("Tarea A", output)
 
     def test_list_tasks_empty(self):
@@ -104,3 +111,47 @@ class TestListTasks(unittest.TestCase):
         output = f.getvalue()
 
         self.assertIn("Invalid status", output)
+
+
+class TestNormalizeStatus(unittest.TestCase):
+    def test_spaces_to_hyphen(self):
+        self.assertEqual(normalize_status("To Do"), Task.STATUS_TODO)
+        self.assertEqual(normalize_status("In Progress"), Task.STATUS_IN_PROGRESS)
+
+    def test_case_insensitive(self):
+        self.assertEqual(normalize_status("DONE"), Task.STATUS_DONE)
+        self.assertEqual(normalize_status("in-progress"), Task.STATUS_IN_PROGRESS)
+
+    def test_invalid(self):
+        self.assertIsNone(normalize_status("banana"))
+
+
+class TestCommandCaseInsensitive(unittest.TestCase):
+    def setUp(self):
+        storage.FILE_PATH = "test_tasks.json"
+        save_tasks([])
+
+    def tearDown(self):
+        if os.path.exists(storage.FILE_PATH):
+            os.remove(storage.FILE_PATH)
+
+    def run_main(self, argv):
+        with patch.object(sys, "argv", argv):
+            f = StringIO()
+            with redirect_stdout(f):
+                main()
+            return f.getvalue()
+
+    def test_add_uppercase_command(self):
+        self.run_main(["taskitor", "ADD", "cli"])
+        tasks = load_tasks()
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0].description, "cli")
+
+    def test_status_mixed_case(self):
+        add_task("task")
+        tasks = load_tasks()
+        self.run_main(["taskitor", "STATUS", str(tasks[0].id), "In ProgrESS"])
+        tasks = load_tasks()
+        self.assertEqual(tasks[0].status, Task.STATUS_IN_PROGRESS)
+


### PR DESCRIPTION
## Summary
- normalize task status input
- allow case-insensitive commands from the CLI
- disable Console highlighting for consistent output
- rename statuses to hyphenated words (to-do, in-progress, done)
- expand unit test coverage for CLI and status handling

## Testing
- `python -m unittest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849d6342390832da5f20fb53263567c